### PR TITLE
修复更新缓存时模板文件夹未创建的问题

### DIFF
--- a/coreframe/app/core/libs/class/template.class.php
+++ b/coreframe/app/core/libs/class/template.class.php
@@ -20,8 +20,8 @@ final class WUZHI_template {
             $template_file = str_replace(COREFRAME_ROOT,'',$template_file);
             exit($template_file." is not exists!" );
         }
-        if(!is_writable(CACHE_ROOT.'templates/')) {
-            exit(CACHE_ROOT.'templates/ 目录不可写');
+        if(!is_dir(CACHE_ROOT.'templates/')) {
+            mkdir(CACHE_ROOT.'templates/', 0777, true);
         }
         $cache_path = CACHE_ROOT.'templates/'.$style.'/'.$m.'/';
         if(!is_dir($cache_path)) {


### PR DESCRIPTION
安装时 caches 目录应该指定了可写，且理论上 caches 目录中的缓存都是可以删除并自动重建的。在缓存管理中更新缓存时，如果 caches/templates 目录不存在就会报错。