### PR TITLE
修复删除文章内容时的BUG

### DIFF
--- a/coreframe/app/content/admin/content.php
+++ b/coreframe/app/content/admin/content.php
@@ -598,7 +598,7 @@ class content extends WUZHI_admin {
         $this->db->delete('block_data', array('keyid' => $keyid));
         
         //返回回收站
-        MSG(L('delete success'), TTP_REFERER, 1000);
+        MSG(L('delete success'), HTTP_REFERER, 1000);
     }
 
     /**


### PR DESCRIPTION
譬如，使用A栏目共享模型（文章模型），那么在A栏目添加一篇文章模型内容B，一篇图片模型内容C，在彻底删除内容C的时候，content_share表能正常删掉内容，	picture_data表没有删。
检查代码，发现删除逻辑有BUG：在删除内容时，附属表选择错误。
该 Commit 修复了上述错误。